### PR TITLE
More flexible dist upload

### DIFF
--- a/upload-distribution.sh
+++ b/upload-distribution.sh
@@ -23,14 +23,17 @@ echo "Workspace: $WORKSPACE"
 pushd $WORKSPACE
 
 ((echo mkdir $DIST_PARENT_DIR/$RELEASE_VERSION; echo quit) | sftp -b - frs.sourceforge.net) || echo "Directory already exists. Skipping creation."
-scp README.md frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION/
-scp changelog.txt frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION/
-scp distribution/target/hibernate-$PROJECT-$RELEASE_VERSION-dist.zip frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION/
-scp distribution/target/hibernate-$PROJECT-$RELEASE_VERSION-dist.tar.gz frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION/
+
+REMOTE_DIST_URL=frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION/
+
+scp README.md $REMOTE_DIST_URL
+scp changelog.txt $REMOTE_DIST_URL
+scp distribution/target/hibernate-$PROJECT-$RELEASE_VERSION-dist.zip $REMOTE_DIST_URL
+scp distribution/target/hibernate-$PROJECT-$RELEASE_VERSION-dist.tar.gz $REMOTE_DIST_URL
 
 MODULE=modules/target/hibernate-$PROJECT-modules-$RELEASE_VERSION-wildfly-10-dist.zip
 if [ -f $MODULE ]; then
-	scp $MODULE frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION/
+	scp $MODULE $REMOTE_DIST_URL
 fi
 
 popd

--- a/upload-distribution.sh
+++ b/upload-distribution.sh
@@ -2,7 +2,7 @@
 
 PROJECT=$1
 RELEASE_VERSION=$2
-DIST_PARENT_DIR=${3:-"/home/frs/project/hibernate/hibernate-$PROJECT"}
+REMOTE_DIST_PARENT_DIR=${3:-"/home/frs/project/hibernate/hibernate-$PROJECT"}
 WORKSPACE=${WORKSPACE:-'.'}
 
 if [ -z "$PROJECT" ]; then
@@ -16,15 +16,15 @@ fi
 
 echo "#####################################################"
 echo "# Uploading Hibernate $PROJECT $RELEASE_VERSION on"
-echo "# SourceForge: $DIST_PARENT_DIR"
+echo "# SourceForge: $REMOTE_DIST_PARENT_DIR"
 echo "#####################################################"
 echo "Workspace: $WORKSPACE"
 
 pushd $WORKSPACE
 
-((echo mkdir $DIST_PARENT_DIR/$RELEASE_VERSION; echo quit) | sftp -b - frs.sourceforge.net) || echo "Directory already exists. Skipping creation."
+((echo mkdir $REMOTE_DIST_PARENT_DIR/$RELEASE_VERSION; echo quit) | sftp -b - frs.sourceforge.net) || echo "Directory already exists. Skipping creation."
 
-REMOTE_DIST_URL=frs.sourceforge.net:$DIST_PARENT_DIR/$RELEASE_VERSION/
+REMOTE_DIST_URL=frs.sourceforge.net:$REMOTE_DIST_PARENT_DIR/$RELEASE_VERSION/
 
 scp README.md $REMOTE_DIST_URL
 scp changelog.txt $REMOTE_DIST_URL

--- a/upload-distribution.sh
+++ b/upload-distribution.sh
@@ -28,12 +28,28 @@ REMOTE_DIST_URL=frs.sourceforge.net:$REMOTE_DIST_PARENT_DIR/$RELEASE_VERSION/
 
 scp README.md $REMOTE_DIST_URL
 scp changelog.txt $REMOTE_DIST_URL
-scp distribution/target/hibernate-$PROJECT-$RELEASE_VERSION-dist.zip $REMOTE_DIST_URL
-scp distribution/target/hibernate-$PROJECT-$RELEASE_VERSION-dist.tar.gz $REMOTE_DIST_URL
 
-MODULE=modules/target/hibernate-$PROJECT-modules-$RELEASE_VERSION-wildfly-10-dist.zip
-if [ -f $MODULE ]; then
-	scp $MODULE $REMOTE_DIST_URL
+# Recursive upload of the dist directory (whose content is project-specific)
+DIST_DIR=distribution/target/dist
+if [ -d $DIST_DIR ]; then
+	# Cd to the dist directory to prevent scp from uploading a "dist" directory
+	pushd $DIST_DIR
+	scp -r . $REMOTE_DIST_URL
+	popd
+fi
+
+# Legacy behavior with explicit uploads - useful for older branches
+LEGACY_DIST_ZIP=distribution/target/hibernate-$PROJECT-$RELEASE_VERSION-dist.zip
+if [ -f $LEGACY_DIST_ZIP ]; then
+	scp $LEGACY_DIST_ZIP $REMOTE_DIST_URL
+fi
+LEGACY_DIST_TAR=distribution/target/hibernate-$PROJECT-$RELEASE_VERSION-dist.tar.gz
+if [ -f $LEGACY_DIST_TAR ]; then
+	scp $LEGACY_DIST_TAR $REMOTE_DIST_URL
+fi
+LEGACY_MODULE=modules/target/hibernate-$PROJECT-modules-$RELEASE_VERSION-wildfly-10-dist.zip
+if [ -f $LEGACY_MODULE ]; then
+	scp $LEGACY_MODULE $REMOTE_DIST_URL
 fi
 
 popd

--- a/upload-documentation.sh
+++ b/upload-documentation.sh
@@ -20,7 +20,12 @@ fi
 
 pushd ${WORKSPACE}
 
-unzip distribution/target/hibernate-$PROJECT-$RELEASE_VERSION-dist.zip -d distribution/target/unpacked
+DIST=distribution/target/dist/hibernate-$PROJECT-$RELEASE_VERSION-dist.zip
+if [ ! -f $DIST ]; then
+	# Legacy layout; see upload-distribution.sh
+	DIST=distribution/target/hibernate-$PROJECT-$RELEASE_VERSION-dist.zip
+fi
+unzip $DIST -d distribution/target/unpacked
 DOCUMENTATION_DIRECTORY=distribution/target/unpacked/hibernate-${PROJECT}-${RELEASE_VERSION}/docs
 
 # Add various metadata to the header


### PR DESCRIPTION
As discussed with @gsmet, we will need a way for projects to upload more than just the traditional dist zip and tar.gz plus the optional "JBoss modules" zip. We need to upload patches from Validator, multiple "JBoss modules" zips from Search, etc.

This changeset allows projects to define what they want uploaded themselves: if a `distribution/target/dist` directory is found, everything in it will be uploaded to sourceforge.

This changeset should be backward-compatible as long as older branches do not generate a `distribution/target/dist` directory, and I don't think they do.

Tested locally against:

* Search: https://github.com/hibernate/hibernate-search/pull/1603
* Validator: https://github.com/hibernate/hibernate-validator/pull/911
* OGM: https://github.com/hibernate/hibernate-ogm/pull/933