### PR TITLE
 Allow projects not to include any version information in their README

### DIFF
--- a/pre-release.rb
+++ b/pre-release.rb
@@ -237,8 +237,13 @@ def update_readme(readme_file_name, release_version)
   updated_readme = readme.gsub(/^\*?Version: .*\*?$/, "*Version: #{release_version} - #{$now.strftime("%d-%m-%Y")}*")
   updated_readme = updated_readme.gsub(/(<dependency>\s*<groupId>org\.hibernate[^\/]*<\/groupId>\s*<artifactId>hibernate[^\/]*<\/artifactId>\s*<version>)[^\/]+(<\/version>)/m, "\\1#{release_version}\\2")
 
-  # To write changes to the file, use:
-  File.open(readme_file_name, "w") {|file| file.puts updated_readme }
+  if readme != updated_readme
+    # To write changes to the file, use:
+    File.open(readme_file_name, "w") {|file| file.puts updated_readme }
+    return true
+  else
+    return false
+  end
 end
 
 #######################################################################################################################
@@ -275,8 +280,9 @@ end
 readme_file_name = Choice.choices[:update_readme]
 if !readme_file_name.nil? and !readme_file_name.empty?
   abort "ERROR: #{readme_file_name} is not a valid file" unless File.exist?(readme_file_name)
-  update_readme(readme_file_name, release_version)
-  git_commit(readme_file_name, "[Jenkins release job] README.md updated by release build #{release_version}")
+  if update_readme(readme_file_name, release_version)
+    git_commit(readme_file_name, "[Jenkins release job] README.md updated by release build #{release_version}")
+  end
 end
 
 change_log_file_name = Choice.choices[:update_changelog]

--- a/validate-release.sh
+++ b/validate-release.sh
@@ -27,12 +27,16 @@ else
 	echo "SUCCESS: tag '$RELEASE_VERSION' does not exist"
 fi
 
-if grep -q "$RELEASE_VERSION" $README ;
+# Only check README updates if it's actually possible that it contains things to update
+if grep -Eq "^\*?Version: .*\*?$|<version>" $README
 then
-	echo "SUCCESS: $README looks updated"
-else
-	echo "ERROR: $README has not been updated"
-	exit 1
+	if grep -q "$RELEASE_VERSION" $README
+	then
+		echo "SUCCESS: $README looks updated"
+	else
+		echo "ERROR: $README has not been updated"
+		exit 1
+	fi
 fi
 
 if grep -q "$RELEASE_VERSION" $CHANGELOG ;

--- a/validate-release.sh
+++ b/validate-release.sh
@@ -21,26 +21,26 @@ git fetch --tags
 
 if [ `git tag -l | grep $RELEASE_VERSION` ]
 then
-        echo "ERROR: tag '$RELEASE_VERSION' already exists, aborting. If you really want to release this version, delete the tag in the workspace first."
-        exit 1
+	echo "ERROR: tag '$RELEASE_VERSION' already exists, aborting. If you really want to release this version, delete the tag in the workspace first."
+	exit 1
 else
-        echo "SUCCESS: tag '$RELEASE_VERSION' does not exist"
+	echo "SUCCESS: tag '$RELEASE_VERSION' does not exist"
 fi
 
 if grep -q "$RELEASE_VERSION" $README ;
 then
-        echo "SUCCESS: $README looks updated"
+	echo "SUCCESS: $README looks updated"
 else
-        echo "ERROR: $README has not been updated"
-        exit 1
+	echo "ERROR: $README has not been updated"
+	exit 1
 fi
 
 if grep -q "$RELEASE_VERSION" $CHANGELOG ;
 then
-        echo "SUCCESS: $CHANGELOG looks updated"
+	echo "SUCCESS: $CHANGELOG looks updated"
 else
-        echo "ERROR: $CHANGELOG has not been updated"
-        exit 1
+	echo "ERROR: $CHANGELOG has not been updated"
+	exit 1
 fi
 
 popd


### PR DESCRIPTION
Before this patch, the release process used to fail for projects that do not include any version information in their README:

* First because this will trigger an attempt to commit without any change in pre-release.rb
* And second because this will make some explicit checks fail