### PR TITLE
Use annotated tag instead of simple tags when releasing

### DIFF
--- a/create-tag.sh
+++ b/create-tag.sh
@@ -16,6 +16,6 @@ if [ -z "$RELEASE_VERSION" ]; then
 fi
 
 git commit -a -m "[Jenkins release job] Preparing release $RELEASE_VERSION"
-git tag $RELEASE_VERSION
+git tag -a -m "Release $RELEASE_VERSION" "$RELEASE_VERSION"
 
 popd


### PR DESCRIPTION
This is important in particular when using 'git describe' to get the
closest tag for a given commit, because non-annotated tags are ignored
by default.